### PR TITLE
junbon/zero_duration

### DIFF
--- a/Changes
+++ b/Changes
@@ -36,3 +36,5 @@ Revision history for Quant-Framework
         Handles negative variance in get_volatility differently.
 0.35    29 Aug 2016
         Dividend refactoring. (Remove Asset.pm and Rename Dividend.pm as Asset.pm).
+0.36    6 Sept 2016
+        Changed closing_tick_on function to accept only a date and sets validation error if get_volatility function is called with zero duration.

--- a/lib/Quant/Framework.pm
+++ b/lib/Quant/Framework.pm
@@ -3,7 +3,7 @@ package Quant::Framework;
 use strict;
 use warnings;
 
-our $VERSION = '0.35';
+our $VERSION = '0.36';
 
 =head1 NAME
 

--- a/lib/Quant/Framework/Spot.pm
+++ b/lib/Quant/Framework/Spot.pm
@@ -166,8 +166,7 @@ sub closing_tick_on {
         aggregation_period => 86400,
     });
 
-    if ($ohlc and scalar @{$ohlc} > 0) {
-
+    if (@$ohlc > 0) {
         # We need a tick, but we can only get an OHLC
         # The epochs for these are set to be the START of the period.
         # So we also need to change it to the closing time. Meh.
@@ -179,7 +178,7 @@ sub closing_tick_on {
         });
     }
 
-    return;
+    return undef;
 }
 
 =head2 $self->set_spot_tick($value)

--- a/lib/Quant/Framework/Spot.pm
+++ b/lib/Quant/Framework/Spot.pm
@@ -158,7 +158,10 @@ sub closing_tick_on {
     $date = Date::Utility->new($date);
 
     my $closing = $self->calendar->closing_on($date);
-    return if not $closing or time <= $closing->epoch;
+    if (not $closing or time <= $closing->epoch) {
+        ##no critic (ProhibitExplicitReturnUndef)
+        return undef;
+    }
 
     my $ohlc = $self->feed_api->ohlc_start_end({
         start_time         => $date,
@@ -178,7 +181,8 @@ sub closing_tick_on {
         });
     }
 
-    return;
+    ##no critic (ProhibitExplicitReturnUndef)
+    return undef;
 }
 
 =head2 $self->set_spot_tick($value)

--- a/lib/Quant/Framework/Spot.pm
+++ b/lib/Quant/Framework/Spot.pm
@@ -158,7 +158,7 @@ sub closing_tick_on {
     $date = Date::Utility->new($date);
 
     my $closing = $self->calendar->closing_on($date);
-    return if not $closing or time <= $closing->epoch;
+    return undef if not $closing or time <= $closing->epoch;
 
     my $ohlc = $self->feed_api->ohlc_start_end({
         start_time         => $date,

--- a/lib/Quant/Framework/Spot.pm
+++ b/lib/Quant/Framework/Spot.pm
@@ -158,7 +158,7 @@ sub closing_tick_on {
     $date = Date::Utility->new($date);
 
     my $closing = $self->calendar->closing_on($date);
-    return undef if not $closing or time <= $closing->epoch;
+    return if not $closing or time <= $closing->epoch;
 
     my $ohlc = $self->feed_api->ohlc_start_end({
         start_time         => $date,
@@ -178,7 +178,7 @@ sub closing_tick_on {
         });
     }
 
-    return undef;
+    return;
 }
 
 =head2 $self->set_spot_tick($value)

--- a/lib/Quant/Framework/Spot.pm
+++ b/lib/Quant/Framework/Spot.pm
@@ -158,7 +158,7 @@ sub closing_tick_on {
     $date = Date::Utility->new($date);
 
     my $closing = $self->calendar->closing_on($date);
-    return unless $closing or time <= $closing->epoch;
+    return if not $closing or time <= $closing->epoch;
 
     my $ohlc = $self->feed_api->ohlc_start_end({
         start_time         => $date,

--- a/lib/Quant/Framework/Spot.pm
+++ b/lib/Quant/Framework/Spot.pm
@@ -152,13 +152,17 @@ Example : $underlying->closing_tick_on("10-Jan-00");
 =cut
 
 sub closing_tick_on {
-    my ($self, $end, $closing) = @_;
-    my $date = Date::Utility->new($end);
+    my ($self, $closing) = @_;
+
+    die 'must pass in a date for closing_tick_on' unless $closing;
+
+    $closing = Date::Utility->new($closing);
+    my $beginning_of_day = $closing->truncate_to_day;
 
     if ($closing and time > $closing->epoch) {
         my $ohlc = $self->feed_api->ohlc_start_end({
-            start_time         => $date,
-            end_time           => $date,
+            start_time         => $beginning_of_day,
+            end_time           => $beginning_of_day,
             aggregation_period => 86400,
         });
 

--- a/lib/Quant/Framework/Spot/DatabaseAPI.pm
+++ b/lib/Quant/Framework/Spot/DatabaseAPI.pm
@@ -152,9 +152,11 @@ Find the first tick which breaches a barrier
 sub get_first_tick {
     my ($self, %args) = @_;
 
-    my ($underlying_symbol, $system_symbol, $pip_size) = @{$args}{qw(underlying system_symbol pip_size)};
-    my $start_time = Date::Utility->new($args{start_time})->db_timestamp;
-    my $end_time = Date::Utility->new($args{end_time} // time)->db_timestamp;
+    my $underlying_symbol = $args{underlying};
+    my $system_symbol     = $args{system_symbol};
+    my $pip_size          = $args{pip_size};
+    my $start_time        = Date::Utility->new($args{start_time})->db_timestamp;
+    my $end_time          = Date::Utility->new($args{end_time} // time)->db_timestamp;
 
     unless ($args{higher} || $args{lower}) {
         die "At least one of higher or lower must be specified";
@@ -166,12 +168,12 @@ sub get_first_tick {
     $statement->bind_param(2, $start_time);
     $statement->bind_param(3, $end_time);
     if ($args{lower}) {
-        $statement->bind_param(4, $args{lower} + $pipsize / 2);
+        $statement->bind_param(4, $args{lower} + $pip_size / 2);
     } else {
         $statement->bind_param(4, undef);
     }
     if ($args{higher}) {
-        $statement->bind_param(5, $args{higher} - $pipsize / 2);
+        $statement->bind_param(5, $args{higher} - $pip_size / 2);
     } else {
         $statement->bind_param(5, undef);
     }

--- a/lib/Quant/Framework/Spot/DatabaseAPI.pm
+++ b/lib/Quant/Framework/Spot/DatabaseAPI.pm
@@ -161,7 +161,7 @@ sub get_first_tick {
         die "At least one of higher or lower must be specified";
     }
 
-    my $statement = $self->dbh->prepare_cached('SELECT * FROM get_tick_first($1, $2, $3, $4, $5)', {}, 5);
+    my $statement = $self->dbh->prepare_cached('SELECT * FROM get_first_tick($1, $2, $3, $4, $5)', {}, 5);
 
     $statement->bind_param(1, $underlying->system_symbol);
     $statement->bind_param(2, $start_time);

--- a/lib/Quant/Framework/Spot/DatabaseAPI.pm
+++ b/lib/Quant/Framework/Spot/DatabaseAPI.pm
@@ -152,10 +152,9 @@ Find the first tick which breaches a barrier
 sub get_first_tick {
     my ($self, %args) = @_;
 
-    my $underlying = $args{underlying};
-    my $pipsize    = $underlying->pip_size;
+    my ($underlying_symbol, $system_symbol, $pip_size) = @{$args}{qw(underlying system_symbol pip_size)};
     my $start_time = Date::Utility->new($args{start_time})->db_timestamp;
-    my $end_time   = Date::Utility->new($args{end_time} // time)->db_timestamp;
+    my $end_time = Date::Utility->new($args{end_time} // time)->db_timestamp;
 
     unless ($args{higher} || $args{lower}) {
         die "At least one of higher or lower must be specified";
@@ -163,7 +162,7 @@ sub get_first_tick {
 
     my $statement = $self->dbh->prepare_cached('SELECT * FROM get_first_tick($1, $2, $3, $4, $5)', {}, 5);
 
-    $statement->bind_param(1, $underlying->system_symbol);
+    $statement->bind_param(1, $system_symbol);
     $statement->bind_param(2, $start_time);
     $statement->bind_param(3, $end_time);
     if ($args{lower}) {
@@ -180,7 +179,7 @@ sub get_first_tick {
     my $tick;
     if (my ($epoch, $quote) = $self->dbh->selectrow_array($statement)) {
         $tick = Quant::Framework::Spot::Tick->new({
-            symbol => $underlying->symbol,
+            symbol => $underlying_symbol,
             epoch  => $epoch,
             quote  => $quote,
         });

--- a/lib/Quant/Framework/Spot/DatabaseAPI.pm
+++ b/lib/Quant/Framework/Spot/DatabaseAPI.pm
@@ -152,11 +152,10 @@ Find the first tick which breaches a barrier
 sub get_first_tick {
     my ($self, %args) = @_;
 
-    my $underlying    = $args{underlying};
-    my $system_symbol = $args{system_symbol};
-    my $pipsize       = $args{pip_size};
-    my $start_time    = Date::Utility->new($args{start_time})->db_timestamp;
-    my $end_time      = Date::Utility->new($args{end_time} // time)->db_timestamp;
+    my $underlying = $args{underlying};
+    my $pipsize    = $underlying->pip_size;
+    my $start_time = Date::Utility->new($args{start_time})->db_timestamp;
+    my $end_time   = Date::Utility->new($args{end_time} // time)->db_timestamp;
 
     unless ($args{higher} || $args{lower}) {
         die "At least one of higher or lower must be specified";
@@ -181,7 +180,7 @@ sub get_first_tick {
     my $tick;
     if (my ($epoch, $quote) = $self->dbh->selectrow_array($statement)) {
         $tick = Quant::Framework::Spot::Tick->new({
-            symbol => $underlying,
+            symbol => $underlying->symbol,
             epoch  => $epoch,
             quote  => $quote,
         });

--- a/lib/Quant/Framework/VolSurface/Delta.pm
+++ b/lib/Quant/Framework/VolSurface/Delta.pm
@@ -132,11 +132,12 @@ sub get_volatility {
 
     # This sanity check prevents negative variance
     # This will happen when we are trying to price a contract that has expired but not settled.
-    if ($args->{from}->epoch < $self->recorded_date->epoch) {
-        $self->validation_error('Requesting a volatility for date in the past. Volatility surface date['
+    if ($args->{from}->epoch < $self->recorded_date->epoch || $args->{from}->epoch == $args->{to}->epoch) {
+        $self->validation_error('Invalid request for get volatility. Surface recorded date ['
                 . $self->recorded_date->datetime
-                . '] requested date['
-                . $args->{from}->datetime
+                . '] requested period ['
+                . $args->{from}->datetime . ' to '
+                . $args->{to}->datetime
                 . ']');
         return 0.01;    # return a 1% volatility but we will not sell on this volatility.
     }

--- a/lib/Quant/Framework/VolSurface/Moneyness.pm
+++ b/lib/Quant/Framework/VolSurface/Moneyness.pm
@@ -113,7 +113,15 @@ sub get_volatility {
     delete $internal_args{to};
     delete $internal_args{from};
 
-    die "Argument 'days' must be positive, non-zero number." if $internal_args{days} <= 0;
+    if ($internal_args{days} <= 0) {
+        $self->validation_error('Invalid request for get volatility. Surface recorded date ['
+                . $self->recorded_date->datetime
+                . '] requested period ['
+                . $args->{from}->datetime . ' to '
+                . $args->{to}->datetime
+                . ']');
+        return 0.01;    # return a 1% volatility but we will not sell on this volatility.
+    }
 
     # we are handling delta seperately because it involves
     # a lot more steps to calculate vol for a delta point

--- a/t/VolSurface/Moneyness/error_check.t
+++ b/t/VolSurface/Moneyness/error_check.t
@@ -145,4 +145,15 @@ subtest "uses smile of the smallest available term structure when we need price 
     );
 };
 
+subtest 'get volatility with invalid period' => sub {
+    lives_ok {
+        is $v->get_volatility(
+                moneyness => 100,
+                from      => $from,
+                to        => $from,
+        ), 0.01, 'get default 1% volatility';
+        like ($v->validation_error, qr/Invalid request for get volatility/, 'volsurface validation error is set.');
+    } 'do not die if get volatility is called with invalid period';
+};
+
 done_testing;

--- a/t/VolSurface/Moneyness/error_check.t
+++ b/t/VolSurface/Moneyness/error_check.t
@@ -147,11 +147,11 @@ subtest "uses smile of the smallest available term structure when we need price 
 
 subtest 'get volatility with invalid period' => sub {
     lives_ok {
-        is $v->get_volatility(
+        is $v->get_volatility({
                 moneyness => 100,
                 from      => $from,
                 to        => $from,
-        ), 0.01, 'get default 1% volatility';
+            }), 0.01, 'get default 1% volatility';
         like ($v->validation_error, qr/Invalid request for get volatility/, 'volsurface validation error is set.');
     } 'do not die if get volatility is called with invalid period';
 };

--- a/t/VolSurface/delta.t
+++ b/t/VolSurface/delta.t
@@ -50,8 +50,13 @@ subtest 'get_volatility for different expiries ' => sub {
     lives_ok {
         my $vol = $surface->get_volatility({delta => 50, to => $now->plus_time_interval('1s'), from => $now->minus_time_interval('1s')});
         is $vol, 0.01, '1% volatility';
-        like ($surface->validation_error, qr/Requesting a volatility for date in the past/, 'volsurface validation error is set.');
+        like ($surface->validation_error, qr/Invalid request for get volatility/, 'volsurface validation error is set.');
     } "do not die if requested date for volatility is in the past";
+    lives_ok {
+        my $vol = $surface->get_volatility({delta => 50, to => $now, from => $now});
+        is $vol, 0.01, '1% volatility';
+        like ($surface->validation_error, qr/Invalid request for get volatility/, 'volsurface validation error is set.');
+    } "do not die if requested dates for volatility are equal";
     lives_ok { $surface->get_volatility({delta => 50, from => $now, to => $now->plus_time_interval('1s')}) }
     "can get volatility when mandatory arguments are provided";
 };


### PR DESCRIPTION
Handles zero duration better. This happens in proposal open contract at expiry when database does not have the exit tick populated. 